### PR TITLE
Ci pipeline failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: ⬣ ESLint
         run: npm run lint
-        working-directory: ./workshop
+        working-directory: ./workshop/${{ github.event.repository.name }}
 
       # TODO: get this working again
       # - name: ⬇️ Install Playwright


### PR DESCRIPTION
Fix CI failure by correcting the working directory for the ESLint step.

The `epicshop add` command clones the workshop into a subdirectory named after the repository (e.g., `./workshop/get-started-with-react`). The ESLint step was configured to run in `./workshop`, which caused it to fail as `package.json` was not found there. This change updates the `working-directory` to `./workshop/${{ github.event.repository.name }}` to correctly locate the `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb2ea7ef-0158-49ba-843d-d41b7b02aca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb2ea7ef-0158-49ba-843d-d41b7b02aca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

